### PR TITLE
Add support for MySQL backend

### DIFF
--- a/rest_framework_tracking/migrations/0001_initial.py
+++ b/rest_framework_tracking/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('remote_addr', models.GenericIPAddressField()),
                 ('host', models.URLField()),
                 ('method', models.CharField(max_length=10)),
-                ('query_params', models.TextField(db_index=True)),
+                ('query_params', models.TextField(null=True, blank=True)),
                 ('data', models.TextField(null=True, blank=True)),
                 ('response', models.TextField(null=True, blank=True)),
                 ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -1,5 +1,6 @@
 from .models import APIRequestLog
 from django.utils.timezone import now
+from rest_framework import exceptions
 
 
 class LoggingMixin(object):
@@ -10,9 +11,14 @@ class LoggingMixin(object):
         request = super(LoggingMixin, self).initialize_request(request, *args, **kwargs)
 
         # get user
-        if request.user.is_authenticated():
-            user = request.user
-        else:  # AnonymousUser
+        try:
+            if request.user.is_authenticated():
+                user = request.user
+            else:  # AnonymousUser
+                user = None
+        except exceptions.AuthenticationFailed:
+            # The AuthenticationFailed exception could be raised by any
+            # authentication backend based in tokens, when those expired.
             user = None
 
         # get data dict

--- a/rest_framework_tracking/models.py
+++ b/rest_framework_tracking/models.py
@@ -27,7 +27,7 @@ class BaseAPIRequestLog(models.Model):
     method = models.CharField(max_length=10)
 
     # query params
-    query_params = models.TextField(db_index=True)
+    query_params = models.TextField(null=True, blank=True)
 
     # POST body data
     data = models.TextField(null=True, blank=True)


### PR DESCRIPTION
Thank you for drf-tracking

In the current implementation, using MySQL backend would break with the following error:
django.db.utils.InternalError: (1170, u"BLOB/TEXT column 'query_params' used in key specification without a key length")

This patch fixes this issue.