### PR TITLE
Fixed bug when token expires.

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -1,6 +1,8 @@
 from .models import APIRequestLog
 from django.utils.timezone import now
 
+from rest_framework import exceptions
+
 
 class LoggingMixin(object):
     """Mixin to log requests"""
@@ -10,9 +12,14 @@ class LoggingMixin(object):
         request = super(LoggingMixin, self).initialize_request(request, *args, **kwargs)
 
         # get user
-        if request.user.is_authenticated():
-            user = request.user
-        else:  # AnonymousUser
+        try:    
+            if request.user.is_authenticated():
+                user = request.user
+            else:  # AnonymousUser
+                user = None
+        except exceptions.AuthenticationFailed:
+            # The AuthenticationFailed exception could be raised by any
+            # authentication backend based in tokens, when those expired.
             user = None
 
         # get data dict


### PR DESCRIPTION
When some token-based authentication backends recive an expired token raise an AuthenticationFailed that generate a 500 error when trying to log, this is hard to find and shouldn't change the original 401 status code to a 500 error.

With try/except we catch the AuthenticationFailed exception raised by the backend, save the record and don't change the normal flow of the original request.