### PR TITLE
Fixed bug when token expires.

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -34,7 +34,7 @@ class LoggingMixin(object):
             user=user,
             requested_at=now(),
             path=request.path,
-            remote_addr=get_real_ip(request),
+            remote_addr=get_real_ip(request) or request.META['REMOTE_ADDR'],
             host=request.get_host(),
             method=request.method,
             query_params=request.query_params.dict(),

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -1,6 +1,8 @@
 from .models import APIRequestLog
 from django.utils.timezone import now
 
+from rest_framework import exceptions
+
 
 class LoggingMixin(object):
     """Mixin to log requests"""
@@ -10,9 +12,14 @@ class LoggingMixin(object):
         request = super(LoggingMixin, self).initialize_request(request, *args, **kwargs)
 
         # get user
-        if request.user.is_authenticated():
-            user = request.user
-        else:  # AnonymousUser
+        try:    
+            if request.user.is_authenticated():
+                user = request.user
+            else:  # AnonymousUser
+                user = None
+        except exceptions.AuthenticationFailed:
+            # The AuthenticationFailed exception could be raised by any
+            # authentication backend based in tokens, when those expired.
             user = None
 
         # get data dict

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -12,7 +12,7 @@ class LoggingMixin(object):
         request = super(LoggingMixin, self).initialize_request(request, *args, **kwargs)
 
         # get user
-        try:    
+        try:
             if request.user.is_authenticated():
                 user = request.user
             else:  # AnonymousUser

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -2,6 +2,7 @@ from .models import APIRequestLog
 from django.utils.timezone import now
 
 from rest_framework import exceptions
+from ipware.ip import get_real_ip
 
 
 class LoggingMixin(object):
@@ -33,7 +34,7 @@ class LoggingMixin(object):
             user=user,
             requested_at=now(),
             path=request.path,
-            remote_addr=request.META['REMOTE_ADDR'],
+            remote_addr=get_real_ip(request),
             host=request.get_host(),
             method=request.method,
             query_params=request.query_params.dict(),


### PR DESCRIPTION
When some token-based authentication backends recive an expired token raise an AuthenticationFailed that generate a 500 error when trying to log, this is hard to find and shouldn't change the original 401 status code to a 500 error.

With try/except we catch the AuthenticationFailed exception raised by the backend, save the record and don't change the normal flow of the original request.