### PR TITLE
Define methods to be logged explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ class LoggingView(LoggingMixin, generics.GenericAPIView):
         return Response('with logging')
 ```
 
+For performance enhancement, explicitly choose methods to be logged using `logging_methods` attribute:
+```python
+class LoggingView(LoggingMixin, generics.CreateModelMixin, generics.GenericAPIView):
+    logging_methods = ['POST', 'PUT']
+    model = ...
+``` 
+
 ## Testing
 
 Install testing requirements.

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -12,7 +12,7 @@ class LoggingMixin(object):
         # check if request method is being logged
         if self.logging_methods != '__all__' and request.method not in self.logging_methods:
             super(LoggingMixin, self).initial(request, *args, **kwargs)
-            return
+            return None
 
         # get data dict
         try:
@@ -50,13 +50,12 @@ class LoggingMixin(object):
         self.request.log.save()
 
     def finalize_response(self, request, response, *args, **kwargs):
-        # check if request method is being logged
-        if self.logging_methods != '__all__' and request.method not in self.logging_methods:
-            response = super(LoggingMixin, self).finalize_response(request, response, *args, **kwargs)
-            return response
-
         # regular finalize response
         response = super(LoggingMixin, self).finalize_response(request, response, *args, **kwargs)
+
+        # check if request method is being logged
+        if self.logging_methods != '__all__' and request.method not in self.logging_methods:
+            return response
 
         # compute response time
         response_timedelta = now() - self.request.log.requested_at

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -3,9 +3,17 @@ from django.utils.timezone import now
 
 
 class LoggingMixin(object):
+    logging_methods = '__all__'
+
     """Mixin to log requests"""
     def initial(self, request, *args, **kwargs):
         """Set current time on request"""
+
+        # check if request method is being logged
+        if self.logging_methods != '__all__' and request.method not in self.logging_methods:
+            super(LoggingMixin, self).initial(request, *args, **kwargs)
+            return
+
         # get data dict
         try:
             data_dict = request.data.dict()
@@ -42,6 +50,11 @@ class LoggingMixin(object):
         self.request.log.save()
 
     def finalize_response(self, request, response, *args, **kwargs):
+        # check if request method is being logged
+        if self.logging_methods != '__all__' and request.method not in self.logging_methods:
+            response = super(LoggingMixin, self).finalize_response(request, response, *args, **kwargs)
+            return response
+
         # regular finalize response
         response = super(LoggingMixin, self).finalize_response(request, response, *args, **kwargs)
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -78,6 +78,11 @@ class TestLoggingMixin(APITestCase):
         # request_at is time of request, not response
         self.assertGreaterEqual((now() - log.requested_at).total_seconds(), 1)
 
+    def test_logging_explicit(self):
+        self.client.get('/explicit-logging')
+        self.client.post('/explicit-logging')
+        self.assertEqual(APIRequestLog.objects.all().count(), 1)
+
     def test_log_anon_user(self):
         self.client.get('/logging')
         log = APIRequestLog.objects.first()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     url(r'^no-logging$', test_views.MockNoLoggingView.as_view()),
     url(r'^logging$', test_views.MockLoggingView.as_view()),
     url(r'^slow-logging$', test_views.MockSlowLoggingView.as_view()),
+    url(r'^explicit-logging$', test_views.MockExplicitLoggingView.as_view()),
     url(r'^session-auth-logging$', test_views.MockSessionAuthLoggingView.as_view()),
     url(r'^token-auth-logging$', test_views.MockTokenAuthLoggingView.as_view()),
     url(r'^json-logging$', test_views.MockJSONLoggingView.as_view()),

--- a/tests/views.py
+++ b/tests/views.py
@@ -25,6 +25,16 @@ class MockSlowLoggingView(LoggingMixin, APIView):
         return Response('with logging')
 
 
+class MockExplicitLoggingView(LoggingMixin, APIView):
+    logging_methods = ['POST']
+
+    def get(self, request):
+        return Response('no logging')
+
+    def post(self, request):
+        return Response('with logging')
+
+
 class MockSessionAuthLoggingView(LoggingMixin, APIView):
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)


### PR DESCRIPTION
That puts a mixin option to choose request methods to be logged. If not provided, all requests are logged as usual.

Usage:

``` python
class LoggingView(LoggingMixin, generics.CreateModelMixin, generics.GenericAPIView):
    logging_methods = ['POST', 'PUT']
    model = ...
```
