### PR TITLE
Remove path and user filter from admin

### DIFF
--- a/rest_framework_tracking/admin.py
+++ b/rest_framework_tracking/admin.py
@@ -8,6 +8,6 @@ class APIRequestLogAdmin(admin.ModelAdmin):
                     'user', 'method',
                     'path', 'remote_addr', 'host',
                     'query_params')
-    list_filter = ('user', 'path', 'method', 'status_code')
+    list_filter = ('method', 'status_code')
 
 admin.site.register(APIRequestLog, APIRequestLogAdmin)


### PR DESCRIPTION
Admin filter have 'user' and 'path', which are very likely to grow out. I think they should be turned off by default.
