### PR TITLE
track 415 errors

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -1,4 +1,5 @@
 from .models import APIRequestLog
+from rest_framework.exceptions import UnsupportedMediaType
 from django.utils.timezone import now
 
 
@@ -11,6 +12,8 @@ class LoggingMixin(object):
             data_dict = request.data.dict()
         except AttributeError:  # if already a dict, can't dictify
             data_dict = request.data
+        except UnsupportedMediaType:
+            data_dict = None
 
         # get IP
         ipaddr = request.META.get("HTTP_X_FORWARDED_FOR", None)

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -165,3 +165,10 @@ class TestLoggingMixin(APITestCase):
         log = APIRequestLog.objects.first()
         self.assertEqual(log.status_code, 404)
         self.assertIn('Not found', log.response)
+
+    def test_log_request_415_error(self):
+        content_type = 'text/plain'
+        self.client.post('/415-error-logging', {}, content_type=content_type)
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.status_code, 415)
+        self.assertIn('Unsupported media type', log.response)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     url(r'^json-logging$', test_views.MockJSONLoggingView.as_view()),
     url(r'^validation-error-logging$', test_views.MockValidationErrorLoggingView.as_view()),
     url(r'^404-error-logging$', test_views.Mock404ErrorLoggingView.as_view()),
+    url(r'^415-error-logging$', test_views.Mock415ErrorLoggingView.as_view()),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -58,3 +58,8 @@ class Mock404ErrorLoggingView(LoggingMixin, APIView):
     def get(self, request):
         empty_qs = APIRequestLog.objects.none()
         return get_list_or_404(empty_qs)
+
+
+class Mock415ErrorLoggingView(LoggingMixin, APIView):
+    def post(self, request):
+        return request.data


### PR DESCRIPTION
Hello! First of all, thank you very much for creating and sharing this package!

While using it, I came across a bug when DRF returns a 415 response, because the exception is raised when trying to access `request.data` (property [`data`](https://github.com/tomchristie/django-rest-framework/blob/67ac0486f504d957fd123c8b913fb93a71cacdcd/rest_framework/request.py#L183) calls [`_load_data_and_files`](https://github.com/tomchristie/django-rest-framework/blob/67ac0486f504d957fd123c8b913fb93a71cacdcd/rest_framework/request.py#L240), which calls [`_parse`](https://github.com/tomchristie/django-rest-framework/blob/67ac0486f504d957fd123c8b913fb93a71cacdcd/rest_framework/request.py#L271), which raises an `UnsupportedMediaType` exception).

This caused DRF to exit `initial` before `self.request.log` was created in `LoggingMixin`, which caused an `AtributeError` exception in `finalize_request`: `AttributeError("'Request' object has no attribute 'log'",)`.

(Lots of "whichs" in this description.)

I hope this PR is useful!
