### PR TITLE
Prefer select_related() over prefetch_related() on user ForeignKey

### DIFF
--- a/rest_framework_tracking/managers.py
+++ b/rest_framework_tracking/managers.py
@@ -3,4 +3,4 @@ from django.db import models
 
 class PrefetchUserManager(models.Manager):
     def get_queryset(self):
-        return super(PrefetchUserManager, self).get_queryset().prefetch_related('user')
+        return super(PrefetchUserManager, self).get_queryset().select_related('user')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -72,12 +72,12 @@ class TestAPIRequestLog(TestCase):
         for i in range(100):
             APIRequestLog.objects.create(remote_addr=self.ip, requested_at=now())
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             [o.user for o in APIRequestLog.objects.all()]
 
     def test_queries_user(self):
         for i in range(100):
             APIRequestLog.objects.create(remote_addr=self.ip, requested_at=now(), user=self.user)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             [o.user for o in APIRequestLog.objects.all()]


### PR DESCRIPTION
Prefer `select_related()` over `prefetch_related()` on user ForeignKey
