### PR TITLE
Update travis/tox/docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,66 @@
 language: python
 
+python:
+  - "3.5"
+
+cache: pip
+
 sudo: false
 
 env:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-docs
     - TOX_ENV=py27-django1.7-drf3.0
+    - TOX_ENV=py33-django1.7-drf3.0
+    - TOX_ENV=py34-django1.7-drf3.0
     - TOX_ENV=py27-django1.7-drf3.1
+    - TOX_ENV=py33-django1.7-drf3.1
+    - TOX_ENV=py34-django1.7-drf3.1
     - TOX_ENV=py27-django1.7-drf3.2
+    - TOX_ENV=py33-django1.7-drf3.2
+    - TOX_ENV=py34-django1.7-drf3.2
     - TOX_ENV=py27-django1.7-drf3.3
+    - TOX_ENV=py33-django1.7-drf3.3
+    - TOX_ENV=py34-django1.7-drf3.3
     - TOX_ENV=py27-django1.8-drf3.0
+    - TOX_ENV=py33-django1.8-drf3.0
+    - TOX_ENV=py34-django1.8-drf3.0
+    - TOX_ENV=py35-django1.8-drf3.0
     - TOX_ENV=py27-django1.8-drf3.1
+    - TOX_ENV=py33-django1.8-drf3.1
+    - TOX_ENV=py34-django1.8-drf3.1
+    - TOX_ENV=py35-django1.8-drf3.1
     - TOX_ENV=py27-django1.8-drf3.2
+    - TOX_ENV=py33-django1.8-drf3.2
+    - TOX_ENV=py34-django1.8-drf3.2
+    - TOX_ENV=py35-django1.8-drf3.2
     - TOX_ENV=py27-django1.8-drf3.3
+    - TOX_ENV=py33-django1.8-drf3.3
+    - TOX_ENV=py34-django1.8-drf3.3
+    - TOX_ENV=py35-django1.8-drf3.3
+    - TOX_ENV=py27-django1.8-drf3.4
+    - TOX_ENV=py33-django1.8-drf3.4
+    - TOX_ENV=py34-django1.8-drf3.4
+    - TOX_ENV=py35-django1.8-drf3.4
+    - TOX_ENV=py27-django1.8-drf3.5
+    - TOX_ENV=py33-django1.8-drf3.5
+    - TOX_ENV=py34-django1.8-drf3.5
+    - TOX_ENV=py35-django1.8-drf3.5
     - TOX_ENV=py27-django1.9-drf3.3
+    - TOX_ENV=py34-django1.9-drf3.3
+    - TOX_ENV=py35-django1.9-drf3.3
+    - TOX_ENV=py27-django1.9-drf3.4
+    - TOX_ENV=py34-django1.9-drf3.4
+    - TOX_ENV=py35-django1.9-drf3.4
+    - TOX_ENV=py27-django1.9-drf3.5
+    - TOX_ENV=py34-django1.9-drf3.5
+    - TOX_ENV=py35-django1.9-drf3.5
+    - TOX_ENV=py27-django1.10-drf3.4
+    - TOX_ENV=py34-django1.10-drf3.4
+    - TOX_ENV=py35-django1.10-drf3.4
+    - TOX_ENV=py27-django1.10-drf3.5
+    - TOX_ENV=py34-django1.10-drf3.5
+    - TOX_ENV=py35-django1.10-drf3.5
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ drf-tracking provides a Django model and DRF view mixin that work together to lo
 
 ## Requirements
 
-* Python 2.7
-* Django (1.7, 1.8. 1.9)
-* Django REST Framework (3.0, 3.1, 3.2, 3.3)
+* Django 1.7, 1.8, 1.9, 1.10
+* Django REST Framework and Python release supporting the version of Django you are using
 
 ## Installation
 
@@ -54,6 +53,7 @@ For instance:
 ```python
 # views.py
 from rest_framework import generics
+from rest_framework.response import Response
 from rest_framework_tracking.mixins import LoggingMixin
 
 class LoggingView(LoggingMixin, generics.GenericAPIView):

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
         <img src="https://travis-ci.org/aschn/drf-tracking.svg?branch=master">
     </a>
     <a href="https://pypi.python.org/pypi/drf-tracking">
-        <img src="https://pypip.in/version/drf-tracking/badge.svg">
+        <img src="https://badge.fury.io/py/drf-tracking.svg">
     </a>
 </div>
 
@@ -25,7 +25,7 @@ drf-tracking provides a Django model and DRF view mixin that work together to lo
 `requested_at` | Date-time that the request was made | DateTimeField
 `response_ms` | Number of milliseconds spent in view code | PositiveIntegerField
 `path` | Target URI of the request, e.g., `"/api/"` | CharField
-`remote_addr` | IP address where the request originated, e.g., `"127.0.0.1"` | GenericIPAddressField
+`remote_addr` | IP address where the request originated (X_FORWARDED_FOR if available, REMOTE_ADDR if not), e.g., `"127.0.0.1"` | GenericIPAddressField
 `host` | Originating host of the request, e.g., `"example.com"` | URLField
 `method` | HTTP method, e.g., `"GET"` | CharField
 `query_params` | Dictionary of request query parameters, as text | TextField
@@ -35,8 +35,8 @@ drf-tracking provides a Django model and DRF view mixin that work together to lo
 
 ## Requirements
 
-* Python (2.7, 3.3, 3.4)
-* Django (1.6, 1.7)
+* Django 1.7, 1.8, 1.9, 1.10
+* Django REST Framework and Python release supporting the version of Django you are using
 
 ## Installation
 
@@ -63,6 +63,7 @@ For instance:
 ```python
 # views.py
 from rest_framework import generics
+from rest_framework.response import Response
 from rest_framework_tracking.mixins import LoggingMixin
 
 class LoggingView(LoggingMixin, generics.GenericAPIView):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,3 +2,5 @@ site_name: drf-tracking
 site_description: Utils to log Django Rest Framework requests to the database
 repo_url: https://github.com/aschn/drf-tracking
 site_dir: html
+extra_css:
+  - css/extra.css

--- a/rest_framework_tracking/__init__.py
+++ b/rest_framework_tracking/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.2.5'
+__version__ = '0.3-dev'

--- a/rest_framework_tracking/admin.py
+++ b/rest_framework_tracking/admin.py
@@ -11,4 +11,5 @@ class APIRequestLogAdmin(admin.ModelAdmin):
     list_filter = ('method', 'status_code')
     search_fields = ('path', 'user__email',)
 
+
 admin.site.register(APIRequestLog, APIRequestLogAdmin)

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -31,7 +31,7 @@ class LoggingMixin(object):
             data=data_dict,
         )
 
-        # regular intitial, including auth check
+        # regular initial, including auth check
         super(LoggingMixin, self).initial(request, *args, **kwargs)
 
         # add user to log after auth

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,10 @@ setup(
     author_email=author_email,
     packages=get_packages(package),
     package_data=get_package_data(package),
-    install_requires=[],
+    install_requires=[
+        'Django>=1.7',
+        'djangorestframework>=3'
+    ],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,10 @@ setup(
         'Development Status :: 2 - Pre-Alpha',
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.7',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
@@ -91,6 +95,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,9 @@
+# coding=utf-8
+from __future__ import absolute_import
+
 from django.conf.urls import url
-import views as test_views
+
+from . import views as test_views
 
 urlpatterns = [
     url(r'^no-logging$', test_views.MockNoLoggingView.as_view()),

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,32 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27}-django{1.7,1.8}-drf{3.0,3.1,3.2,3.3},
-       {py27}-django{1.9}-drf{3.3}
+       {py27,py33,py34}-django1.7-drf{3.0,3.1,3.2,3.3},
+       {py27,py33,py34,py35}-django1.8-drf{3.0,3.1,3.2,3.3,3.4,3.5},
+       {py27,py35,py35}-django1.9-drf{3.3,3.4,3.5},
+       {py27,py34,py35}-django1.10-drf{3.4,3.5},
 
 [testenv]
 commands = ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.7: Django==1.7.7
-       django1.8: Django==1.8.6
-       django1.9: Django==1.9.0
+       django1.7: Django==1.7.11
+       django1.8: Django==1.8.16
+       django1.9: Django==1.9.11
+       django1.10: Django==1.10.3
        drf3.0: djangorestframework==3.0.5
        drf3.1: djangorestframework==3.1.3
        drf3.2: djangorestframework==3.2.5
-       drf3.3: djangorestframework==3.3.2
+       drf3.3: djangorestframework==3.3.3
+       drf3.4: djangorestframework==3.4.7
+       drf3.5: djangorestframework==3.5.3
        pytest-django==2.8
+basepython =
+       py35: python3.5
+       py34: python3.4
+       py33: python3.3
+       py27: python2.7
 
 [testenv:py27-flake8]
 commands = ./runtests.py --lintonly


### PR DESCRIPTION
Fixes #24

Also adds Travis/tox tests for more versions of Django/DRF/Python3, although I am guessing some of the older versions' tests could be dropped before merging

Please let me know @aschn @avelis if there is anything that can be done to help bring about a new release of this package, thanks!