### PR TITLE
Travis tests + MySQL initial migration fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,78 +1,172 @@
+sudo: false
 language: python
-
 python:
   - "3.5"
-
 cache: pip
-
-sudo: false
-
 env:
-    - TOX_ENV=py27-flake8
-    - TOX_ENV=py27-docs
-    - TOX_ENV=py27-django1.7-drf3.0
-    - TOX_ENV=py33-django1.7-drf3.0
-    - TOX_ENV=py34-django1.7-drf3.0
-    - TOX_ENV=py27-django1.7-drf3.1
-    - TOX_ENV=py33-django1.7-drf3.1
-    - TOX_ENV=py34-django1.7-drf3.1
-    - TOX_ENV=py27-django1.7-drf3.2
-    - TOX_ENV=py33-django1.7-drf3.2
-    - TOX_ENV=py34-django1.7-drf3.2
-    - TOX_ENV=py27-django1.7-drf3.3
-    - TOX_ENV=py33-django1.7-drf3.3
-    - TOX_ENV=py34-django1.7-drf3.3
-    - TOX_ENV=py27-django1.8-drf3.0
-    - TOX_ENV=py33-django1.8-drf3.0
-    - TOX_ENV=py34-django1.8-drf3.0
-    - TOX_ENV=py35-django1.8-drf3.0
-    - TOX_ENV=py27-django1.8-drf3.1
-    - TOX_ENV=py33-django1.8-drf3.1
-    - TOX_ENV=py34-django1.8-drf3.1
-    - TOX_ENV=py35-django1.8-drf3.1
-    - TOX_ENV=py27-django1.8-drf3.2
-    - TOX_ENV=py33-django1.8-drf3.2
-    - TOX_ENV=py34-django1.8-drf3.2
-    - TOX_ENV=py35-django1.8-drf3.2
-    - TOX_ENV=py27-django1.8-drf3.3
-    - TOX_ENV=py33-django1.8-drf3.3
-    - TOX_ENV=py34-django1.8-drf3.3
-    - TOX_ENV=py35-django1.8-drf3.3
-    - TOX_ENV=py27-django1.8-drf3.4
-    - TOX_ENV=py33-django1.8-drf3.4
-    - TOX_ENV=py34-django1.8-drf3.4
-    - TOX_ENV=py35-django1.8-drf3.4
-    - TOX_ENV=py27-django1.8-drf3.5
-    - TOX_ENV=py33-django1.8-drf3.5
-    - TOX_ENV=py34-django1.8-drf3.5
-    - TOX_ENV=py35-django1.8-drf3.5
-    - TOX_ENV=py27-django1.9-drf3.3
-    - TOX_ENV=py34-django1.9-drf3.3
-    - TOX_ENV=py35-django1.9-drf3.3
-    - TOX_ENV=py27-django1.9-drf3.4
-    - TOX_ENV=py34-django1.9-drf3.4
-    - TOX_ENV=py35-django1.9-drf3.4
-    - TOX_ENV=py27-django1.9-drf3.5
-    - TOX_ENV=py34-django1.9-drf3.5
-    - TOX_ENV=py35-django1.9-drf3.5
-    - TOX_ENV=py27-django1.10-drf3.4
-    - TOX_ENV=py34-django1.10-drf3.4
-    - TOX_ENV=py35-django1.10-drf3.4
-    - TOX_ENV=py27-django1.10-drf3.5
-    - TOX_ENV=py34-django1.10-drf3.5
-    - TOX_ENV=py35-django1.10-drf3.5
-
+  - TOX_ENV=py27-flake8
+  - TOX_ENV=py27-docs
+  - TOX_ENV=py27-django1.7-drf3.0 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.7-drf3.0 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.7-drf3.0 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.7-drf3.0 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.7-drf3.0 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.7-drf3.0 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.7-drf3.0 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.7-drf3.0 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.7-drf3.0 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.7-drf3.1 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.7-drf3.1 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.7-drf3.1 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.7-drf3.1 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.7-drf3.1 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.7-drf3.1 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.7-drf3.1 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.7-drf3.1 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.7-drf3.1 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.7-drf3.2 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.7-drf3.2 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.7-drf3.2 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.7-drf3.2 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.7-drf3.2 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.7-drf3.2 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.7-drf3.2 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.7-drf3.2 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.7-drf3.2 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.7-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.7-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.7-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.7-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.7-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.7-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.7-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.7-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.7-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.8-drf3.0 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.8-drf3.0 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.8-drf3.0 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.8-drf3.0 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.8-drf3.0 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.8-drf3.0 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.8-drf3.0 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.8-drf3.0 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.8-drf3.0 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.8-drf3.0 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.8-drf3.0 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.8-drf3.0 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.8-drf3.1 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.8-drf3.1 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.8-drf3.1 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.8-drf3.1 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.8-drf3.1 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.8-drf3.1 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.8-drf3.1 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.8-drf3.1 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.8-drf3.1 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.8-drf3.1 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.8-drf3.1 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.8-drf3.1 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.8-drf3.2 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.8-drf3.2 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.8-drf3.2 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.8-drf3.2 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.8-drf3.2 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.8-drf3.2 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.8-drf3.2 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.8-drf3.2 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.8-drf3.2 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.8-drf3.2 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.8-drf3.2 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.8-drf3.2 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.8-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.8-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.8-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.8-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.8-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.8-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.8-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.8-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.8-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.8-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.8-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.8-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.8-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.8-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.8-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.8-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.8-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.8-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.8-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.8-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.8-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.8-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.8-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.8-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.8-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.8-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.8-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py33-django1.8-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py33-django1.8-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py33-django1.8-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.8-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.8-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.8-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.8-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.8-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.8-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.9-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.9-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.9-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.9-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.9-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.9-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.9-drf3.3 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.9-drf3.3 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.9-drf3.3 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.9-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.9-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.9-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.9-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.9-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.9-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.9-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.9-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.9-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.9-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.9-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.9-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.9-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.9-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.9-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.9-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.9-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.9-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.10-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.10-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.10-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.10-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.10-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.10-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.10-drf3.4 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.10-drf3.4 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.10-drf3.4 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.10-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.10-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.10-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.10-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.10-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.10-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.10-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.10-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.10-drf3.5 DATABASE_URL=postgres://postgres@/test_db
 matrix:
   fast_finish: true
-
 install:
   - pip install -r requirements.txt
-  - pip install tox python-coveralls
-
+  - pip install tox python-coveralls psycopg2 mysqlclient
 script:
-    - tox -e $TOX_ENV
-    - coverage run runtests.py
-
+  - tox -e $TOX_ENV
+  - coverage run runtests.py
 after_success:
   coveralls
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ djangorestframework>=3.0
 
 # Test requirements
 pytest-django>=2.8
+django-environ~=0.4.1
 pytest>=2.7
 pytest-cov>=1.8
 flake8>=2.4

--- a/rest_framework_tracking/migrations/0001_initial.py
+++ b/rest_framework_tracking/migrations/0001_initial.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
                 ('remote_addr', models.GenericIPAddressField()),
                 ('host', models.URLField()),
                 ('method', models.CharField(max_length=10)),
-                ('query_params', models.TextField(blank=True, db_index=True, null=True)),
+                ('query_params', models.TextField(blank=True, null=True)),
                 ('data', models.TextField(blank=True, null=True)),
                 ('response', models.TextField(blank=True, null=True)),
                 ('status_code', models.PositiveIntegerField(blank=True, null=True)),

--- a/rest_framework_tracking/models.py
+++ b/rest_framework_tracking/models.py
@@ -27,7 +27,7 @@ class BaseAPIRequestLog(models.Model):
     method = models.CharField(max_length=10)
 
     # query params
-    query_params = models.TextField(db_index=True, null=True, blank=True)
+    query_params = models.TextField(null=True, blank=True)
 
     # POST body data
     data = models.TextField(null=True, blank=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,14 @@
+# coding=utf-8
+
+
 def pytest_configure():
     from django.conf import settings
-
+    import environ
     settings.configure(
         DEBUG_PROPAGATE_EXCEPTIONS=True,
-        DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3',
-                               'NAME': ':memory:'}},
+        DATABASES={
+            'default': environ.Env().db(default="sqlite://")  # DATABASE_URL should be specified in the environment
+        },
         SITE_ID=1,
         SECRET_KEY='not very secret in tests',
         USE_I18N=True,

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -66,7 +66,7 @@ class TestLoggingMixin(APITestCase):
         log = APIRequestLog.objects.first()
 
         # response time is very short
-        self.assertLessEqual(log.response_ms, 7)
+        self.assertLessEqual(log.response_ms, 20)
 
         # request_at is time of request, not response
         self.assertGreaterEqual((now() - log.requested_at).total_seconds(), 0.002)

--- a/tox.ini
+++ b/tox.ini
@@ -8,20 +8,25 @@ envlist =
 
 [testenv]
 commands = ./runtests.py --fast
+passenv =
+       DATABASE_URL
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.7: Django==1.7.11
-       django1.8: Django==1.8.16
-       django1.9: Django==1.9.11
-       django1.10: Django==1.10.3
-       drf3.0: djangorestframework==3.0.5
-       drf3.1: djangorestframework==3.1.3
-       drf3.2: djangorestframework==3.2.5
-       drf3.3: djangorestframework==3.3.3
-       drf3.4: djangorestframework==3.4.7
-       drf3.5: djangorestframework==3.5.3
-       pytest-django==2.8
+       django1.7: Django~=1.7.11
+       django1.8: Django~=1.8.16
+       django1.9: Django~=1.9.11
+       django1.10: Django~=1.10.3
+       drf3.0: djangorestframework~=3.0.5
+       drf3.1: djangorestframework~=3.1.3
+       drf3.2: djangorestframework~=3.2.5
+       drf3.3: djangorestframework~=3.3.3
+       drf3.4: djangorestframework~=3.4.7
+       drf3.5: djangorestframework~=3.5.3
+       pytest-django
+       django-environ
+       psycopg2
+       mysqlclient
 basepython =
        py35: python3.5
        py34: python3.4


### PR DESCRIPTION
Use Travis to run tests with Postgres/MySQL

Mostly worked this out by looking at how https://github.com/django-guardian/django-guardian does stuff 

Also should fix #29 - amended the initial commit like suggested

The Travis matrix is probably too big at this stage, there must be a better way to organise this. Though it is a good way to find flaky tests 😄 