### PR TITLE
Use a more relaxed split() to split ipaddr from HTTP_X_FORWARDED_FOR

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -16,7 +16,7 @@ class LoggingMixin(object):
         ipaddr = request.META.get("HTTP_X_FORWARDED_FOR", None)
         if ipaddr:
             # X_FORWARDED_FOR returns client1, proxy1, proxy2,...
-            ipaddr = ipaddr.split(", ")[0]
+            ipaddr = [x.strip() for x in ipaddr.split(",")][0]
         else:
             ipaddr = request.META.get("REMOTE_ADDR", "")
 


### PR DESCRIPTION
The IP address from HTTP_X_FORWARDED_FOR is currently split using ", ". Split with "," instead to handle IPs such as "x.x.x.x,x.x.x.x"