### PR TITLE
Fix crash on ParseError in LoggingMixin (#27)

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -1,5 +1,4 @@
 from .models import APIRequestLog
-from rest_framework.exceptions import UnsupportedMediaType
 from django.utils.timezone import now
 
 
@@ -14,14 +13,6 @@ class LoggingMixin(object):
         if self.logging_methods != '__all__' and request.method not in self.logging_methods:
             super(LoggingMixin, self).initial(request, *args, **kwargs)
             return None
-
-        # get data dict
-        try:
-            data_dict = request.data.dict()
-        except AttributeError:  # if already a dict, can't dictify
-            data_dict = request.data
-        except UnsupportedMediaType:
-            data_dict = None
 
         # get IP
         ipaddr = request.META.get("HTTP_X_FORWARDED_FOR", None)
@@ -39,7 +30,6 @@ class LoggingMixin(object):
             host=request.get_host(),
             method=request.method,
             query_params=request.query_params.dict(),
-            data=data_dict,
         )
 
         # regular initial, including auth check
@@ -50,7 +40,18 @@ class LoggingMixin(object):
         if user.is_anonymous():
             user = None
         self.request.log.user = user
-        self.request.log.save()
+
+        # get data dict
+        try:
+            # Accessing request.data *for the first time* parses the request body, which may raise
+            # ParseError and UnsupportedMediaType exceptions. It's important not to swallow these,
+            # as (depending on implementation details) they may only get raised this once, and
+            # DRF logic needs them to be raised by the view for error handling to work correctly.
+            self.request.log.data = self.request.data.dict()
+        except AttributeError:  # if already a dict, can't dictify
+            self.request.log.data = self.request.data
+        finally:
+            self.request.log.save()
 
     def finalize_response(self, request, response, *args, **kwargs):
         # regular finalize response

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -183,3 +183,10 @@ class TestLoggingMixin(APITestCase):
         log = APIRequestLog.objects.first()
         self.assertEqual(log.status_code, 415)
         self.assertIn('Unsupported media type', log.response)
+
+    def test_log_request_body_parse_error(self):
+        content_type = 'application/json'
+        self.client.post('/400-body-parse-error-logging', 'INVALID JSON', content_type=content_type)
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.status_code, 400)
+        self.assertIn('parse error', log.response)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     url(r'^validation-error-logging$', test_views.MockValidationErrorLoggingView.as_view()),
     url(r'^404-error-logging$', test_views.Mock404ErrorLoggingView.as_view()),
     url(r'^415-error-logging$', test_views.Mock415ErrorLoggingView.as_view()),
+    url(r'^400-body-parse-error-logging$', test_views.Mock400BodyParseErrorLoggingView.as_view()),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -73,3 +73,11 @@ class Mock404ErrorLoggingView(LoggingMixin, APIView):
 class Mock415ErrorLoggingView(LoggingMixin, APIView):
     def post(self, request):
         return request.data
+
+
+class Mock400BodyParseErrorLoggingView(LoggingMixin, APIView):
+    def post(self, request):
+        # raise ParseError for request with mismatched Content-Type and body:
+        # (though only if it's the first access to request.data)
+        request.data
+        return Response('Data processed')


### PR DESCRIPTION
Accessing `request.data` in `LoggingMixin.initial` may raise a `ParseError`, which leads to  a later crash during `finalize_response` (see #27).

We can't just catch and swallow `ParseErrors`, because they need to happen for the error handling logic to work correctly. So we need to work around them and access `request.data` late, after everything else is done, so `ParseErrors` can be propagated.