### PR TITLE
Add pytz as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ setup(
     package_data=get_package_data(package),
     install_requires=[
         'Django>=1.7',
-        'djangorestframework>=3'
+        'djangorestframework>=3',
+        'pytz',
     ],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
Needed for the `date_hierarchy` in the `APIRequestLogAdmin` 
<img width="1040" alt="screen shot 2017-01-26 at 21 45 38" src="https://cloud.githubusercontent.com/assets/2990876/22351658/e0174bf8-e410-11e6-977b-ae2d50182d25.png">

It could technically be an optional dependency since someone might not be using the admin though

