### PR TITLE
fix(): remove wrong param in traceback.format_exc

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -58,7 +58,7 @@ class LoggingMixin(object):
         response = super(LoggingMixin, self).handle_exception(exc)
 
         # log error
-        self.request.log.errors = traceback.format_exc(exc)
+        self.request.log.errors = traceback.format_exc()
         self.request.log.status_code = response.status_code
         self.request.log.save()
 


### PR DESCRIPTION
Based on the documentation, [format_exc](https://docs.python.org/3.6/library/traceback.html#traceback.print_exc) is expecting an int value, it's supposed to fix the PR #18 