### PR TITLE
feat(): logging should never break the API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ wheel>=0.24
 
 # MkDocs for documentation previews/deploys
 mkdocs>=0.13
+
+mock

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -41,16 +41,20 @@ class LoggingMixin(object):
             view_method = method.lower()
 
         # save to log
-        self.request.log = APIRequestLog.objects.create(
-            requested_at=now(),
-            path=request.path,
-            view=view_name,
-            view_method=view_method,
-            remote_addr=ipaddr,
-            host=request.get_host(),
-            method=request.method,
-            query_params=_clean_data(request.query_params.dict()),
-        )
+        try:
+            self.request.log = APIRequestLog.objects.create(
+                requested_at=now(),
+                path=request.path,
+                view=view_name,
+                view_method=view_method,
+                remote_addr=ipaddr,
+                host=request.get_host(),
+                method=request.method,
+                query_params=_clean_data(request.query_params.dict()),
+            )
+        except Exception:
+            # tracking db constraints should not create a failure on the API
+            return
 
         # regular initial, including auth check
         super(LoggingMixin, self).initial(request, *args, **kwargs)

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -96,6 +96,8 @@ class LoggingMixin(object):
         # check if request method is being logged
         if self.logging_methods != '__all__' and request.method not in self.logging_methods:
             return response
+        if not hasattr(self.request, 'log'):
+            return response
 
         # compute response time
         response_timedelta = now() - self.request.log.requested_at

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ deps =
        flaky
        psycopg2
        mysqlclient
+       mock
 basepython =
        py35: python3.5
        py34: python3.4


### PR DESCRIPTION
I had the case that while being attacked, the attacker changed the x-forwarded-for header with a non-ip in there. The logging db insert fails on the inet field.

No issue while logging should actually block the API behind.

I would like to put a giant try/except around the entire code actually BUT a comment on line 65 disturbs me (where the request data actually saved in `request.log`).