### PR TITLE
Adds Django 1.11 testing support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,6 +159,24 @@ env:
   - TOX_ENV=py35-django1.10-drf3.5 DATABASE_URL=sqlite://
   - TOX_ENV=py35-django1.10-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
   - TOX_ENV=py35-django1.10-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.11-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.11-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.11-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.11-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.11-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.11-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.11-drf3.5 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.11-drf3.5 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.11-drf3.5 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py27-django1.11-drf3.6 DATABASE_URL=sqlite://
+  - TOX_ENV=py27-django1.11-drf3.6 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py27-django1.11-drf3.6 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py34-django1.11-drf3.6 DATABASE_URL=sqlite://
+  - TOX_ENV=py34-django1.11-drf3.6 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py34-django1.11-drf3.6 DATABASE_URL=postgres://postgres@/test_db
+  - TOX_ENV=py35-django1.11-drf3.6 DATABASE_URL=sqlite://
+  - TOX_ENV=py35-django1.11-drf3.6 DATABASE_URL=mysql://root:@localhost/test_db
+  - TOX_ENV=py35-django1.11-drf3.6 DATABASE_URL=postgres://postgres@/test_db
 matrix:
   fast_finish: true
 install:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ drf-tracking provides a Django model and DRF view mixin that work together to lo
 
 ## Requirements
 
-* Django 1.7, 1.8, 1.9, 1.10
+* Django 1.7, 1.8, 1.9, 1.10, 1.11
 * Django REST Framework and Python release supporting the version of Django you are using
 
 ## Installation

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
        {py27,py33,py34,py35}-django1.8-drf{3.0,3.1,3.2,3.3,3.4,3.5},
        {py27,py35,py35}-django1.9-drf{3.3,3.4,3.5},
        {py27,py34,py35}-django1.10-drf{3.4,3.5},
+       {py27,py34,py35,py36}-django1.11-drf{3.5,3.6},
 
 [testenv]
 commands = ./runtests.py --fast
@@ -23,6 +24,7 @@ deps =
        drf3.3: djangorestframework~=3.3.3
        drf3.4: djangorestframework~=3.4.7
        drf3.5: djangorestframework~=3.5.3
+       drf3.6: djangorestframework~=3.6.2
        pytest-django
        django-environ
        flaky
@@ -30,6 +32,7 @@ deps =
        mysqlclient
        mock
 basepython =
+       py36: python3.6
        py35: python3.5
        py34: python3.4
        py33: python3.3


### PR DESCRIPTION
Initial configuration files needed to begin having TravisCI test Django
1.11 with tox.