### PR TITLE
[#53] Fix: 'Request' object has no attribute 'log'

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -82,9 +82,10 @@ class LoggingMixin(object):
         response = super(LoggingMixin, self).handle_exception(exc)
 
         # log error
-        self.request.log.errors = traceback.format_exc()
-        self.request.log.status_code = response.status_code
-        self.request.log.save()
+        if hasattr(self.request, 'log'):
+            self.request.log.errors = traceback.format_exc()
+            self.request.log.status_code = response.status_code
+            self.request.log.save()
 
         # return
         return response


### PR DESCRIPTION
A pretty straightforward fix.

If there is no `log` attribute for any reason (such as we logged out), then we don't try to write an exception there.