### PR TITLE
Save log once when request fully processed

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -40,21 +40,17 @@ class LoggingMixin(object):
         else:
             view_method = method.lower()
 
-        # save to log
-        try:
-            self.request.log = APIRequestLog.objects.create(
-                requested_at=now(),
-                path=request.path,
-                view=view_name,
-                view_method=view_method,
-                remote_addr=ipaddr,
-                host=request.get_host(),
-                method=request.method,
-                query_params=_clean_data(request.query_params.dict()),
-            )
-        except Exception:
-            # tracking db constraints should not create a failure on the API
-            return
+        # create log
+        self.request.log = APIRequestLog(
+            requested_at=now(),
+            path=request.path,
+            view=view_name,
+            view_method=view_method,
+            remote_addr=ipaddr,
+            host=request.get_host(),
+            method=request.method,
+            query_params=_clean_data(request.query_params.dict()),
+        )
 
         # regular initial, including auth check
         super(LoggingMixin, self).initial(request, *args, **kwargs)
@@ -74,8 +70,6 @@ class LoggingMixin(object):
             self.request.log.data = _clean_data(self.request.data.dict())
         except AttributeError:  # if already a dict, can't dictify
             self.request.log.data = _clean_data(self.request.data)
-        finally:
-            self.request.log.save()
 
     def handle_exception(self, exc):
         # basic handling

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -78,8 +78,6 @@ class LoggingMixin(object):
         # log error
         if hasattr(self.request, 'log'):
             self.request.log.errors = traceback.format_exc()
-            self.request.log.status_code = response.status_code
-            self.request.log.save()
 
         # return
         return response


### PR DESCRIPTION
Hi,

Ok this is maybe completely dummy from me, but couldn't we save us some writings to DB by saving `APIRequestLog` only once ; at the end of the request processing (either from `handle_exception` or `finalize_response`)?

Here is a proposal for this. Tests seem to pass.

Regards 🙂