### PR TITLE
Prevent log save failure to break API call

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -100,7 +100,11 @@ class LoggingMixin(object):
         self.request.log.response = response.rendered_content
         self.request.log.status_code = response.status_code
         self.request.log.response_ms = response_ms
-        self.request.log.save()
+        try:
+            self.request.log.save()
+        except:
+            # ensure that a DB error doesn't prevent API call to continue as expected
+            pass
 
         # return
         return response

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -5,6 +5,7 @@ import pytest
 from django.contrib.auth.models import User
 from django.utils.timezone import now
 from flaky import flaky
+from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIRequestFactory, APITestCase
 from rest_framework_tracking.models import APIRequestLog
@@ -254,9 +255,9 @@ class TestLoggingMixin(APITestCase):
         self.assertEqual(log.status_code, 400)
         self.assertIn('parse error', log.response)
 
-    @mock.patch('rest_framework_tracking.mixins.APIRequestLog')
-    def test_does_not_crash_on_data_not_fitting_in_the_db(self, mock_apirequestlog):
-        mock_apirequestlog.objects = mock.MagicMock()
-        mock_apirequestlog.objects.create = mock.MagicMock(side_effect=Exception("integrity"))
-        self.client.get('/logging')
+    @mock.patch('rest_framework_tracking.models.APIRequestLog.save')
+    def test_log_doesnt_prevent_api_call_if_log_save_fails(self, mock_apirequestlog_save):
+        mock_apirequestlog_save.side_effect = Exception('db failure')
+        response = self.client.get('/logging')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(APIRequestLog.objects.all().count(), 0)


### PR DESCRIPTION
Hi,

This is a follow-up of the discussion in PR #55.

If something is going wrong during log saving, we don't want the API to fail and throw out an error to the end user.

To do this, silently swallow any exception throwed by save().

A test is provided to check that the response status_code of the API is still 200 even in the event of a DB failure.

Best regards!