### PR TITLE
Custom logging condition (clean history)

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -9,13 +9,6 @@ class LoggingMixin(object):
 
     """Mixin to log requests"""
     def initial(self, request, *args, **kwargs):
-        """Set current time on request"""
-
-        # check if request method is being logged
-        if self.logging_methods != '__all__' and request.method not in self.logging_methods:
-            super(LoggingMixin, self).initial(request, *args, **kwargs)
-            return None
-
         # get IP
         ipaddr = request.META.get("HTTP_X_FORWARDED_FOR", None)
         if ipaddr:
@@ -86,9 +79,7 @@ class LoggingMixin(object):
         # regular finalize response
         response = super(LoggingMixin, self).finalize_response(request, response, *args, **kwargs)
 
-        # check if request method is being logged
-        if self.logging_methods != '__all__' and request.method not in self.logging_methods:
-            return response
+        # check if request is being logged
         if not hasattr(self.request, 'log'):
             return response
 
@@ -97,17 +88,25 @@ class LoggingMixin(object):
         response_ms = int(response_timedelta.total_seconds() * 1000)
 
         # save to log
-        self.request.log.response = response.rendered_content
-        self.request.log.status_code = response.status_code
-        self.request.log.response_ms = response_ms
-        try:
-            self.request.log.save()
-        except:
-            # ensure that a DB error doesn't prevent API call to continue as expected
-            pass
+        if (self._should_log(request, response)):
+            self.request.log.response = response.rendered_content
+            self.request.log.status_code = response.status_code
+            self.request.log.response_ms = response_ms
+            try:
+                self.request.log.save()
+            except:
+                # ensure that a DB error doesn't prevent API call to continue as expected
+                pass
 
         # return
         return response
+
+    def _should_log(self, request, response):
+        """
+        Method that should return True if this request should be logged.
+        By default, check if the request method is in logging_methods.
+        """
+        return self.logging_methods == '__all__' or request.method in self.logging_methods
 
 
 def _clean_data(data):

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -4,7 +4,7 @@ from django.utils.timezone import now
 import traceback
 
 
-class LoggingMixin(object):
+class BaseLoggingMixin(object):
     logging_methods = '__all__'
 
     """Mixin to log requests"""
@@ -46,7 +46,7 @@ class LoggingMixin(object):
         )
 
         # regular initial, including auth check
-        super(LoggingMixin, self).initial(request, *args, **kwargs)
+        super(BaseLoggingMixin, self).initial(request, *args, **kwargs)
 
         # add user to log after auth
         user = request.user
@@ -66,7 +66,7 @@ class LoggingMixin(object):
 
     def handle_exception(self, exc):
         # basic handling
-        response = super(LoggingMixin, self).handle_exception(exc)
+        response = super(BaseLoggingMixin, self).handle_exception(exc)
 
         # log error
         if hasattr(self.request, 'log'):
@@ -77,7 +77,7 @@ class LoggingMixin(object):
 
     def finalize_response(self, request, response, *args, **kwargs):
         # regular finalize response
-        response = super(LoggingMixin, self).finalize_response(request, response, *args, **kwargs)
+        response = super(BaseLoggingMixin, self).finalize_response(request, response, *args, **kwargs)
 
         # check if request is being logged
         if not hasattr(self.request, 'log'):
@@ -107,6 +107,18 @@ class LoggingMixin(object):
         By default, check if the request method is in logging_methods.
         """
         return self.logging_methods == '__all__' or request.method in self.logging_methods
+
+
+class LoggingMixin(BaseLoggingMixin):
+    pass
+
+
+class LoggingErrorsMixin(BaseLoggingMixin):
+    """
+    Log only errors
+    """
+    def _should_log(self, request, response):
+        return response.status_code >= 400
 
 
 def _clean_data(data):

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -94,6 +94,11 @@ class TestLoggingMixin(APITestCase):
         self.client.post('/explicit-logging')
         self.assertEqual(APIRequestLog.objects.all().count(), 1)
 
+    def test_custom_check_logging(self):
+        self.client.get('/custom-check-logging')
+        self.client.post('/custom-check-logging')
+        self.assertEqual(APIRequestLog.objects.all().count(), 1)
+
     def test_log_anon_user(self):
         self.client.get('/logging')
         log = APIRequestLog.objects.first()

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -99,6 +99,11 @@ class TestLoggingMixin(APITestCase):
         self.client.post('/custom-check-logging')
         self.assertEqual(APIRequestLog.objects.all().count(), 1)
 
+    def test_errors_logging(self):
+        self.client.get('/errors-logging')
+        self.client.post('/errors-logging')
+        self.assertEqual(APIRequestLog.objects.all().count(), 1)
+
     def test_log_anon_user(self):
         self.client.get('/logging')
         log = APIRequestLog.objects.first()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     url(r'^logging$', test_views.MockLoggingView.as_view()),
     url(r'^slow-logging$', test_views.MockSlowLoggingView.as_view()),
     url(r'^explicit-logging$', test_views.MockExplicitLoggingView.as_view()),
+    url(r'^custom-check-logging$', test_views.MockCustomCheckLoggingView.as_view()),
     url(r'^session-auth-logging$', test_views.MockSessionAuthLoggingView.as_view()),
     url(r'^token-auth-logging$', test_views.MockTokenAuthLoggingView.as_view()),
     url(r'^json-logging$', test_views.MockJSONLoggingView.as_view()),

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     url(r'^slow-logging$', test_views.MockSlowLoggingView.as_view()),
     url(r'^explicit-logging$', test_views.MockExplicitLoggingView.as_view()),
     url(r'^custom-check-logging$', test_views.MockCustomCheckLoggingView.as_view()),
+    url(r'^errors-logging$', test_views.MockLoggingErrorsView.as_view()),
     url(r'^session-auth-logging$', test_views.MockSessionAuthLoggingView.as_view()),
     url(r'^token-auth-logging$', test_views.MockTokenAuthLoggingView.as_view()),
     url(r'^json-logging$', test_views.MockJSONLoggingView.as_view()),

--- a/tests/views.py
+++ b/tests/views.py
@@ -37,6 +37,20 @@ class MockExplicitLoggingView(LoggingMixin, APIView):
         return Response('with logging')
 
 
+class MockCustomCheckLoggingView(LoggingMixin, APIView):
+    def _should_log(self, request, response):
+        """
+        Log only if response contains 'log'
+        """
+        return 'log' in response.data
+
+    def get(self, request):
+        return Response('with logging')
+
+    def post(self, request):
+        return Response('no recording')
+
+
 class MockSessionAuthLoggingView(LoggingMixin, APIView):
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)

--- a/tests/views.py
+++ b/tests/views.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import serializers, viewsets, mixins
 from rest_framework.exceptions import APIException
-from rest_framework_tracking.mixins import LoggingMixin
+from rest_framework_tracking.mixins import LoggingErrorsMixin, LoggingMixin
 from rest_framework_tracking.models import APIRequestLog
 from tests.test_serializers import ApiRequestLogSerializer
 import time
@@ -49,6 +49,14 @@ class MockCustomCheckLoggingView(LoggingMixin, APIView):
 
     def post(self, request):
         return Response('no recording')
+
+
+class MockLoggingErrorsView(LoggingErrorsMixin, APIView):
+    def get(self, request):
+        raise APIException('with logging')
+
+    def post(self, request):
+        return Response('no logging')
 
 
 class MockSessionAuthLoggingView(LoggingMixin, APIView):


### PR DESCRIPTION
This is a follow-up of #59:

> As promised, here is a PR trying to address an issue that many developers may encounter: **how to provide my own condition for logging?**
> 
> What I propose here is quite simple:
> * The test that checked if the request is in `logging_methods` is moved to its own method `_should_log`. This method is called at the end of the process, before returning response, so that we can provide both `request` and `response` to this method. This way, we could implement any logic we want in it.
> * Rename `LoggingMixin` to `BaseLoggingMixin` so that developers can easily extend it with their own `_should_log` method. `LoggingMixin` just inherits `BaseLoggingMixin` without any changes.
> * To address more specifically issue #52, propose a `LoggingErrorsMixin` which will only log errors by implementing a `_should_log` method that log only responses with `status_code >= 400`.
> 
> If you need more details about the implementation, feel free to ask.
> 
> If we merge this, we'll have to update the README to explain these new features.

This PR is the same but with a clean Git history, as discussed with @avelis.

Regards 🙂