### PR TITLE
Fix Coverage.py configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+include = rest_framework_tracking/*

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ local/
 
 !.gitignore
 !.travis.yml
+!.coveragerc


### PR DESCRIPTION
Hi @avelis,

I hope I don't bother you too much with all my PRs! This is just a small configuration fix.

Currently, the default configuration was running coverage on our code-base but also on the dependencies, giving us a quite poor coverage score (~40%).

With this configuration, the coverage takes only into account our source code (which is, obviously, what we care about). We then have a decent coverage score of 97%.

Best regards!