### PR TITLE
Unit test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: python
 python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
   - "3.5"
 cache: pip
 env:

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -73,12 +73,13 @@ class TestLoggingMixin(APITestCase):
     def test_log_time_fast(self):
         self.client.get('/logging')
         log = APIRequestLog.objects.first()
-
         # response time is very short
         self.assertLessEqual(log.response_ms, 20)
 
         # request_at is time of request, not response
-        self.assertGreaterEqual((now() - log.requested_at).total_seconds(), 0.002)
+        threshold = 0.002
+        saved_delay = (now() - log.requested_at).total_seconds()
+        self.assertAlmostEqual(threshold, saved_delay, 2)
 
     def test_log_time_slow(self):
         self.client.get('/slow-logging')


### PR DESCRIPTION
The test is trying to assert that the difference of the logs
requested_at time and right now are basically the same. Using a
rounding argument of up to 2 decimal places instead of the 7 (default).