### PR TITLE
Log request body on parsing errors

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -42,6 +42,7 @@ class BaseLoggingMixin(object):
             remote_addr=ipaddr,
             host=request.get_host(),
             method=request.method,
+            data=request.body,
             query_params=self._clean_data(request.query_params.dict()),
         )
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -285,6 +285,7 @@ class TestLoggingMixin(APITestCase):
         self.client.post('/400-body-parse-error-logging', 'INVALID JSON', content_type=content_type)
         log = APIRequestLog.objects.first()
         self.assertEqual(log.status_code, 400)
+        self.assertEqual(log.data, 'INVALID JSON')
         self.assertIn('parse error', log.response)
 
     @mock.patch('rest_framework_tracking.models.APIRequestLog.save')


### PR DESCRIPTION
This will allow inspecting the actual content of the request that caused the parsing or content type error.  If the `request.data` is successfully parsed, the `log.data` will be updated with the parsed data.