### PR TITLE
(fix) Validate that `CLEANED_SUBSTITUTE` is str.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ class LoggingView(LoggingMixin, generics.CreateModelMixin, generics.GenericAPIVi
 
 ## Security
 
-By default drf-tracking is hidding the values of those fields `{'api', 'token', 'key', 'secret', 'password', 'signature'}`.
+By default drf-tracking is hiding the values of those fields `{'api', 'token', 'key', 'secret', 'password', 'signature'}`.
 The default list hast been taken from Django itself ([https://github.com/django/django/blob/stable/1.11.x/django/contrib/auth/__init__.py#L50](https://github.com/django/django/blob/stable/1.11.x/django/contrib/auth/__init__.py#L50)).
 
-You can complet this list with your own list by putting the fields you want to be hidden in the `sensitive_fields` parameter of your view
+You can complet this list with your own list by putting the fields you want to be hidden in the `sensitive_fields` parameter of your view.
 
 ```python
 class LoggingView(LoggingMixin, generics.CreateModelMixin, generics.GenericAPIView):

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -5,11 +5,14 @@ import traceback
 
 
 class BaseLoggingMixin(object):
-    SENSITIVE_FIELDS = {'api', 'token', 'key', 'secret', 'password', 'signature'}
     CLEANED_SUBSTITUTE = '********************'
 
     logging_methods = '__all__'
     sensitive_fields = {}
+
+    def __init__(self, *args, **kwargs):
+        assert isinstance(self.CLEANED_SUBSTITUTE, str), 'CLEANED_SUBSTITUTE must be a string.'
+        super(BaseLoggingMixin, self).__init__(*args, **kwargs)
 
     """Mixin to log requests"""
     def initial(self, request, *args, **kwargs):
@@ -128,10 +131,11 @@ class BaseLoggingMixin(object):
             return [self._clean_data(d) for d in data]
 
         if isinstance(data, dict):
-            data = dict(data)
+            SENSITIVE_FIELDS = {'api', 'token', 'key', 'secret', 'password', 'signature'}
 
+            data = dict(data)
             if self.sensitive_fields:
-                self.SENSITIVE_FIELDS = self.SENSITIVE_FIELDS | {field.lower() for field in self.sensitive_fields}
+                SENSITIVE_FIELDS = SENSITIVE_FIELDS | {field.lower() for field in self.sensitive_fields}
 
             for key, value in data.items():
                 try:
@@ -140,7 +144,7 @@ class BaseLoggingMixin(object):
                     pass
                 if isinstance(value, list) or isinstance(value, dict):
                     data[key] = self._clean_data(value)
-                if key.lower() in self.SENSITIVE_FIELDS:
+                if key.lower() in SENSITIVE_FIELDS:
                     data[key] = self.CLEANED_SUBSTITUTE
         return data
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -239,6 +239,10 @@ class TestLoggingMixin(APITestCase):
                          u'var1': {u'api': BaseLoggingMixin.CLEANED_SUBSTITUTE}
                          })
 
+    def test_invalid_cleaned_substitute_fails(self):
+        with self.assertRaises(AssertionError):
+            self.client.get('/invalid-cleaned-substitute-logging')
+
     def test_log_text_response(self):
         self.client.get('/logging')
         log = APIRequestLog.objects.first()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     url(r'^slow-logging$', test_views.MockSlowLoggingView.as_view()),
     url(r'^explicit-logging$', test_views.MockExplicitLoggingView.as_view()),
     url(r'^sensitive-fields-logging$', test_views.MockSensitiveFieldsLoggingView.as_view()),
+    url(r'^invalid-cleaned-substitute-logging$', test_views.MockInvalidCleanedSubstituteLoggingView.as_view()),
     url(r'^custom-check-logging$', test_views.MockCustomCheckLoggingView.as_view()),
     url(r'^errors-logging$', test_views.MockLoggingErrorsView.as_view()),
     url(r'^session-auth-logging$', test_views.MockSessionAuthLoggingView.as_view()),

--- a/tests/views.py
+++ b/tests/views.py
@@ -44,6 +44,10 @@ class MockSensitiveFieldsLoggingView(LoggingMixin, APIView):
         return Response('with logging')
 
 
+class MockInvalidCleanedSubstituteLoggingView(LoggingMixin, APIView):
+    CLEANED_SUBSTITUTE = 1
+
+
 class MockCustomCheckLoggingView(LoggingMixin, APIView):
     def _should_log(self, request, response):
         """


### PR DESCRIPTION
* Add related tests.
* Move `SENSITIVE_FIELDS` back in `_clean_data` function in order users cannot change it.
refs:#pr81