### PR TITLE
(fix) Ensure at application level that response duration is positive.

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -87,18 +87,14 @@ class BaseLoggingMixin(object):
         response = super(BaseLoggingMixin, self).finalize_response(request, response, *args, **kwargs)
 
         # check if request is being logged
-        if not hasattr(self.request, 'log'):
-            return response
-
-        # save to log
-        if (self._should_log(request, response)):
+        if hasattr(self.request, 'log') and self._should_log(request, response):
             # compute response time
             response_timedelta = now() - self.request.log.requested_at
             response_ms = int(response_timedelta.total_seconds() * 1000)
 
             self.request.log.response = response.rendered_content
             self.request.log.status_code = response.status_code
-            self.request.log.response_ms = response_ms
+            self.request.log.response_ms = max(response_ms, 0)
             try:
                 self.request.log.save()
             except Exception:

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import pytest
 import ast
+import datetime
 from django.contrib.auth.models import User
 from django.utils.timezone import now
 from flaky import flaky
@@ -329,3 +330,13 @@ class TestLoggingMixin(APITestCase):
         response = self.client.get('/logging')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(APIRequestLog.objects.all().count(), 0)
+
+    @mock.patch('rest_framework_tracking.mixins.now')
+    def test_log_doesnt_fail_with_negative_response_ms(self, mock_now):
+        mock_now.side_effect = [
+            datetime.datetime(2017, 12, 1, 10, 0, 10),
+            datetime.datetime(2017, 12, 1, 10)
+        ]
+        self.client.get('/logging')
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.response_ms, 0)


### PR DESCRIPTION
Hi @avelis , this pr handles issue #79. I do not know if anyone else have this problem because I wasn't able to reproduce it. But we are observing it occasionally. 

Thanks