### PR TITLE
refactor(): test urls usage for django 1.10

### DIFF
--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -6,6 +6,7 @@ import ast
 import datetime
 from django.contrib.auth.models import User
 from django.utils.timezone import now
+from django.test.utils import override_settings
 from flaky import flaky
 from rest_framework import status
 from rest_framework.authtoken.models import Token
@@ -23,9 +24,8 @@ from .views import MockLoggingView
 pytestmark = pytest.mark.django_db
 
 
+@override_settings(ROOT_URLCONF='tests.urls')
 class TestLoggingMixin(APITestCase):
-
-    urls = 'tests.urls'
 
     def test_nologging_no_log_created(self):
         self.client.get('/no-logging')


### PR DESCRIPTION
Remove the warning in tests for this:
```
tests/test_mixins.py::TestLoggingMixin::test_no_log_view_method_name
  /Users/triat/Dev/pix4d/drf-tracking/.tox/py35-django1.9-drf3.5/lib/python3.5/site-packages/django/test/testcases.py:230: RemovedInDjango110Warning: SimpleTestCase.urls is deprecated and will be removed in Django 1.10. Use @override_settings(ROOT_URLCONF=...) in TestLoggingMixin instead.
    self._urlconf_setup()
```