### PR TITLE
Fix #23 - handle log without TransactionManagementError

### DIFF
--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -74,12 +74,12 @@ class BaseLoggingMixin(object):
                     self.handle_log()
                 elif response.exception and not connection.in_atomic_block or not response.exception:
                     self.handle_log()
-                else:
+                elif response.exception:
                     # respone with exception (HTTP status like: 401, 404, etc)
                     # pointwise disable atomic block for handle log (TransactionManagementError)
-                    connection.in_atomic_block = False
+                    connection.set_rollback(True)
+                    connection.set_rollback(False)
                     self.handle_log()
-                    connection.in_atomic_block = True
             except Exception as e:
                 # ensure that all exceptions raised by handle_log
                 # doesn't prevent API call to continue as expected

--- a/rest_framework_tracking/mixins.py
+++ b/rest_framework_tracking/mixins.py
@@ -66,7 +66,9 @@ class BaseLoggingMixin(object):
                     'data': self._clean_data(self.log['data'])
                 }
             )
-            if response.exception and not connection.in_atomic_block or not response.exception:
+            if not connection.settings_dict.get('ATOMIC_REQUESTS'):
+                self.handle_log()
+            elif response.exception and not connection.in_atomic_block or not response.exception:
                 self.handle_log()
             else:
                 # respone with exception (HTTP status like: 401, 404, etc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ def pytest_configure():
             'django.contrib.auth.hashers.CryptPasswordHasher',
         ),
     )
+    settings.DATABASES['default']['ATOMIC_REQUESTS'] = True
+    settings.DATABASES['default']['AUTOCOMMIT'] = True
 
     try:
         import oauth_provider  # NOQA

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
-from django.utils.timezone import now
+from django.utils.timezone import now, timedelta
 from rest_framework_tracking.models import APIRequestLog
 import pytest
 
@@ -25,9 +25,9 @@ class TestAPIRequestLog(TestCase):
         self.assertEqual(log.user, self.user)
 
     def test_create_timestamp(self):
-        before = now()
+        before = now() - timedelta(seconds=1)
         log = APIRequestLog.objects.create(remote_addr=self.ip, requested_at=now())
-        after = now()
+        after = now() + timedelta(seconds=1)
 
         self.assertLess(log.requested_at, after)
         self.assertGreater(log.requested_at, before)


### PR DESCRIPTION
Hello! I got this error today: https://github.com/aschn/drf-tracking/issues/23.

How to reproduce?

1. View:
```Python
from rest_framework import generics
from rest_framework.response import Response
from rest_framework_tracking.mixins import LoggingMixin

class LoggingView(LoggingMixin, generics.GenericAPIView):
    logging_methods = ['GET']

    def get(self, request):
        return Response('with logging')
```
2. Enable any DRF authorization (I using tokens).
3. Open API endpoint without token or get 404 for any another API endpoint (with logging)

Thats all - when I open API endpoint I have no store any logs in database.
And I have no any error messages from system...

This works that because we have `try ... catch` statement: https://github.com/aschn/drf-tracking/blob/master/rest_framework_tracking/mixins.py#L66

My PR have the fix this error using simple way.

I hope you may fast see this PR and merging it. Thank's!

P.S. I think another fix https://github.com/aschn/drf-tracking/pull/48 is not good decision.


