### PR TITLE
Fixed is_anonymous for django2.0

### DIFF
--- a/rest_framework_tracking/base_mixins.py
+++ b/rest_framework_tracking/base_mixins.py
@@ -124,7 +124,10 @@ class BaseLoggingMixin(object):
     def _get_user(self, request):
         """Get user."""
         user = request.user
-        if not user.is_authenticated:
+        is_anonymous_user = user.is_anonymous
+        if type(is_anonymous_user) != bool:
+            is_anonymous_user = is_anonymous_user()
+        if is_anonymous_user:
             return None
         return user
 


### PR DESCRIPTION
- Part of https://github.com/aschn/drf-tracking/issues/115
- Subset of https://github.com/aschn/drf-tracking/pull/100
- In contrast with #100, this does not drop support for older versions of python
- This is just a part fix, but should allow most use cases for django==2.0, full fix in #100
- Tested with Django 2.0.5