### PR TITLE
Remove query_params explicity conversion to dict

### DIFF
--- a/rest_framework_tracking/base_mixins.py
+++ b/rest_framework_tracking/base_mixins.py
@@ -66,7 +66,7 @@ class BaseLoggingMixin(object):
                     'path': request.path,
                     'host': request.get_host(),
                     'method': request.method,
-                    'query_params': self._clean_data(request.query_params.dict()),
+                    'query_params': self._clean_data(request.query_params),
                     'user': self._get_user(request),
                     'response_ms': self._get_response_ms(),
                     'response': self._clean_data(rendered_content),


### PR DESCRIPTION
- This explicit conversion to dict is dropping all the values with same key
- This is already being done in line 169 https://github.com/aschn/drf-tracking/blob/57344c65fe39923ab2debbf581d9fd0dbc46b2fa/rest_framework_tracking/base_mixins.py#L169
- Fixes #126