### PR TITLE
switch decode source encoding from ascii to utf-8

### DIFF
--- a/rest_framework_tracking/base_mixins.py
+++ b/rest_framework_tracking/base_mixins.py
@@ -159,7 +159,7 @@ class BaseLoggingMixin(object):
         eg: sensitive_fields = {'field1', 'field2'}
         """
         if isinstance(data, bytes):
-            data = data.decode()
+            data = data.decode('utf-8')
 
         if isinstance(data, list):
             return [self._clean_data(d) for d in data]


### PR DESCRIPTION
UnicodeDecodeError fix on python 2.7 / django 1.11 #129 

Tested with Python 2.7.15 / Django 1.11.16 and Python 2.3.7 / Django 2.1.3 