### PR TITLE
Stop data.decode() from crashing with UnicodeDecodeError

### DIFF
--- a/rest_framework_tracking/base_mixins.py
+++ b/rest_framework_tracking/base_mixins.py
@@ -5,8 +5,6 @@ import traceback
 from django.db import connection
 from django.utils.timezone import now
 
-logger = logging.getLogger(__name__)
-
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +157,7 @@ class BaseLoggingMixin(object):
         eg: sensitive_fields = {'field1', 'field2'}
         """
         if isinstance(data, bytes):
-            data = data.decode()
+            data = data.decode(errors='replace')
 
         if isinstance(data, list):
             return [self._clean_data(d) for d in data]

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import pytest
 import ast
 import datetime
+from io import BytesIO
 import json
 from django.contrib.auth.models import User
 from django.utils.timezone import now
@@ -278,6 +279,23 @@ class TestLoggingMixin(APITestCase):
 
     def test_log_json_post_response(self):
         self.client.post('/json-logging', {}, format='json')
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.response, u'{"post":"response"}')
+
+    def test_log_multipart_post_response(self):
+        self.client.post('/multipart-logging', {}, format='multipart')
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.response, u'{"post":"response"}')
+
+    def test_log_multipart_utf8_encoded_file_post_response(self):
+        file = BytesIO('test data'.encode('utf-8'))
+        self.client.post('/multipart-logging', {'file': file}, format='multipart')
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.response, u'{"post":"response"}')
+
+    def test_log_multipart_utf16_encoded_file_post_response(self):
+        file = BytesIO('test data'.encode('utf-16'))
+        self.client.post('/multipart-logging', {'file': file}, format='multipart')
         log = APIRequestLog.objects.first()
         self.assertEqual(log.response, u'{"post":"response"}')
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     url(r'^session-auth-logging$', test_views.MockSessionAuthLoggingView.as_view()),
     url(r'^token-auth-logging$', test_views.MockTokenAuthLoggingView.as_view()),
     url(r'^json-logging$', test_views.MockJSONLoggingView.as_view()),
+    url(r'^multipart-logging$', test_views.MockMultipartLoggingView.as_view()),
     url(r'^validation-error-logging$', test_views.MockValidationErrorLoggingView.as_view()),
     url(r'^404-error-logging$', test_views.Mock404ErrorLoggingView.as_view()),
     url(r'^500-error-logging$', test_views.Mock500ErrorLoggingView.as_view()),

--- a/tests/views.py
+++ b/tests/views.py
@@ -151,6 +151,11 @@ class MockJSONLoggingView(LoggingMixin, APIView):
         return Response({'post': 'response'})
 
 
+class MockMultipartLoggingView(LoggingMixin, APIView):
+    def post(self, request):
+        return Response({'post': 'response'})
+
+
 class MockValidationErrorLoggingView(LoggingMixin, APIView):
     def get(self, request):
         raise serializers.ValidationError('bad input')


### PR DESCRIPTION
This is a potential solution to the issues popping up when drf-tracking (running in Python 3) gets binary data which is encoded in something other than UTF-8. See #125.

The idea is just to ignore errors in the decoding process... Personally, I don't think drf-tracking should crash the stack just because it can't log the request. Luckily, in this case, just a keyword argument to the [bytes.decode()](https://docs.python.org/3.6/library/stdtypes.html#bytes.decode) function works... Instead of `errors='replace'`, it could also be `errors='ignore'`.

For issue #129 which is a Python 2 problem (since UTF-8 is the default in Python 3), we can combine this commit with PR #130.