### PR TITLE
Removed setting request body as log data because it is reassigned anyway.

### DIFF
--- a/rest_framework_tracking/base_mixins.py
+++ b/rest_framework_tracking/base_mixins.py
@@ -24,7 +24,6 @@ class BaseLoggingMixin(object):
     def initial(self, request, *args, **kwargs):
         self.log = {}
         self.log['requested_at'] = now()
-        self.log['data'] = self._clean_data(request.body)
 
         super(BaseLoggingMixin, self).initial(request, *args, **kwargs)
 


### PR DESCRIPTION
Furthermore `data.decode()` in `_clean_data` raises an `UnicodeDecodeError` exception when a file is uploaded.  
Versions: django  2.1.5 and django rest framework 3.9.0