### PR TITLE
Override max_length Defaults

### DIFF
--- a/rest_framework_tracking/base_models.py
+++ b/rest_framework_tracking/base_models.py
@@ -10,7 +10,8 @@ class BaseAPIRequestLog(models.Model):
     """ Logs Django rest framework API requests """
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
-        on_delete=models.SET_NULL, null=True,
+        on_delete=models.SET_NULL,
+        null=True,
         blank=True,
     )
     requested_at = models.DateTimeField(db_index=True)

--- a/rest_framework_tracking/base_models.py
+++ b/rest_framework_tracking/base_models.py
@@ -8,23 +8,25 @@ from .managers import PrefetchUserManager
 @python_2_unicode_compatible
 class BaseAPIRequestLog(models.Model):
     """ Logs Django rest framework API requests """
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True,
-                             blank=True)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL, null=True,
+        blank=True,
+    )
     requested_at = models.DateTimeField(db_index=True)
     response_ms = models.PositiveIntegerField(default=0)
-    path = models.CharField(max_length=200, db_index=True)
+    path = models.CharField(
+        max_length=getattr(settings, 'DRF_TRACKING_PATH_LENGTH', 200),
+        db_index=True,
+    )
     view = models.CharField(
-        max_length=200,
+        max_length=getattr(settings, 'DRF_TRACKING_VIEW_LENGTH', 200),
         null=True,
         blank=True,
         db_index=True,
     )
-
-    # NOTE: Choosing the longest verb in English language - ought be good
-    #       enough for a while
-    VIEW_METHOD_MAX_LENGTH = len('Floccinaucinihilipilificate')
     view_method = models.CharField(
-        max_length=VIEW_METHOD_MAX_LENGTH,
+        max_length=getattr(settings, 'DRF_TRACKING_VIEW_METHOD_LENGTH', 27),
         null=True,
         blank=True,
         db_index=True,


### PR DESCRIPTION
Allows for settings custom settings to override old defaults, e.g.
```
DRF_TRACKING_PATH_LENGTH = 500
DRF_TRACKING_VIEW_LENGTH = 150
DRF_TRACKING_VIEW_METHOD_LENGTH = 50
```

To update in your project:
```
./manage.py makemigrations
./manage.py migrate
```