### PR TITLE
update for support django 3.0.0>

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ flaky = "*"
 flake8 = "*"
 tox = "*"
 mock = "*"
-Django = ">=1.11"
+Django = ">=3.0"
 
 [requires]
-python_version = "3.7"
+python_version = "3.6.9"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: drf-tracking
 site_description: Utils to log Django Rest Framework requests to the database
-repo_url: https://github.com/aschn/drf-tracking
+repo_url: https://github.com/freezedice1220/drf-tracking
 site_dir: html
 extra_css:
   - css/extra.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Minimum Django and REST framework version
-Django>=1.11
+Django>=3.0
 djangorestframework>=3.5
 
 # Test requirements

--- a/rest_framework_tracking/base_models.py
+++ b/rest_framework_tracking/base_models.py
@@ -1,11 +1,9 @@
 from django.db import models
 from django.conf import settings
-from django.utils.six import python_2_unicode_compatible
 
 from .managers import PrefetchUserManager
 
 
-@python_2_unicode_compatible
 class BaseAPIRequestLog(models.Model):
     """ Logs Django rest framework API requests """
     user = models.ForeignKey(


### PR DESCRIPTION
django 3.0 drop Python 2 compatibility. six & python_2_unicode_compatible was removed.